### PR TITLE
Update example of `nargo prove` usage

### DIFF
--- a/versioned_docs/version-0.9.0/getting_started/01_hello_world.md
+++ b/versioned_docs/version-0.9.0/getting_started/01_hello_world.md
@@ -113,7 +113,7 @@ y = "2"
 Prove the valid execution of your Noir program with your preferred proof name, for example `p`:
 
 ```sh
-nargo prove p
+nargo prove -p p
 ```
 
 A new folder _proofs_ would then be generated in your project directory, containing the proof file


### PR DESCRIPTION
Running `nargo prove p` as currently indicated by this tutorial results in:

```
➜  noir_hello_world nargo prove p
error: unexpected argument 'p' found
```

The current version of `nargo` instead expects this to be `nargo prove -p p`, which yields the expected results.